### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ['main']
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/toviszsolt/stormflow/security/code-scanning/4](https://github.com/toviszsolt/stormflow/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not modify repository contents and primarily reads files and uploads coverage reports, the permissions can be restricted to `contents: read`. This block should be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
