### PR TITLE
Potential fix for code scanning alert no. 5: Prototype-polluting function

### DIFF
--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -110,6 +110,10 @@ const objPathSet = (obj, path, value) => {
     const rawKey = keys[i];
     const isIndex = rawKey === `${+rawKey}`;
     const key = isIndex ? +rawKey : rawKey;
+
+    // Block prototype pollution for all keys
+    if (['__proto__', 'constructor'].includes(String(key))) return;
+
     const isLast = i === keys.length - 1;
 
     if (isLast) {
@@ -120,7 +124,6 @@ const objPathSet = (obj, path, value) => {
           delete node[key];
         }
       } else {
-        if (['__proto__', 'constructor'].includes(String(key))) return;
         node[key] = value;
       }
     } else {


### PR DESCRIPTION
Potential fix for [https://github.com/toviszsolt/stormflow/security/code-scanning/5](https://github.com/toviszsolt/stormflow/security/code-scanning/5)

To fix the issue, we need to ensure that the `objPathSet` function blocks prototype pollution comprehensively. This involves validating all keys in the path (`keys[i]`) to ensure they are not `__proto__` or `constructor`. Additionally, we should prevent deletion or splicing operations on these special properties. The fix will involve adding a validation step for `key` at the beginning of the loop and ensuring that no unsafe operations are performed on these properties.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
